### PR TITLE
Fix team member permissions and add current user endpoint

### DIFF
--- a/admin-frontend/src/components/Sidebar.jsx
+++ b/admin-frontend/src/components/Sidebar.jsx
@@ -90,27 +90,41 @@ const Sidebar = () => {
 
   // Check if user has permission for a specific module
   const hasPermission = (permission) => {
+    // Debug logging
+    console.log("=== PERMISSION CHECK DEBUG ===");
+    console.log("User object:", user);
+    console.log("Checking permission:", permission);
+    console.log("User role:", user?.role);
+    console.log("User permissions:", user?.permissions);
+    console.log("Specific permission value:", user?.permissions?.[permission]);
+
     // If no user is logged in, deny access
     if (!user) {
+      console.log("No user - denying access");
       return false;
     }
 
     // Super admin or admin has access to all modules
     if (user?.role === "super-admin" || user?.role === "admin") {
+      console.log("Super admin/admin - granting access");
       return true;
     }
 
     // For hardcoded admin email (temporary fix)
     if (user?.email === "admin@gsbpathy.com") {
+      console.log("Hardcoded admin email - granting access");
       return true;
     }
 
     // Team members need specific permissions
     if (user?.role === "team_member" && user?.permissions) {
       // Check if the permission exists and is true (boolean value)
-      return user.permissions[permission] === true;
+      const hasAccess = user.permissions[permission] === true;
+      console.log("Team member permission check result:", hasAccess);
+      return hasAccess;
     }
 
+    console.log("No matching condition - denying access");
     return false;
   };
 

--- a/admin-frontend/src/components/Sidebar.jsx
+++ b/admin-frontend/src/components/Sidebar.jsx
@@ -106,8 +106,9 @@ const Sidebar = () => {
     }
 
     // Team members need specific permissions
-    if (user?.permissions && user.permissions[permission]) {
-      return user.permissions[permission].read === true;
+    if (user?.role === "team_member" && user?.permissions) {
+      // Check if the permission exists and is true (boolean value)
+      return user.permissions[permission] === true;
     }
 
     return false;

--- a/admin-frontend/src/context/AuthContext.jsx
+++ b/admin-frontend/src/context/AuthContext.jsx
@@ -125,7 +125,6 @@ export const AuthProvider = ({ children }) => {
       setIsAuthenticated(true);
       setUser({
         ...teamMember,
-        role: "team-member",
         isTeamMember: true,
       });
 

--- a/admin-frontend/src/context/AuthContext.jsx
+++ b/admin-frontend/src/context/AuthContext.jsx
@@ -49,14 +49,27 @@ export const AuthProvider = ({ children }) => {
             email: tokenPayload.email,
             role: tokenPayload.role,
           });
-        } else {
-          // For team members, use token data with default permissions
-          setUser({
-            id: tokenPayload.id,
-            email: tokenPayload.email,
-            role: "team-member",
-            permissions: {}, // Will be populated on login
-          });
+                } else {
+          // For team members, fetch current user data to get permissions
+          try {
+            const userResponse = await axios.get(`${API_BASE}/teams/current`, {
+              headers: { Authorization: `Bearer ${token}` }
+            });
+            setUser({
+              ...userResponse.data.user,
+              isTeamMember: true,
+            });
+          } catch (fetchError) {
+            console.error("Error fetching team member data:", fetchError);
+            // Fallback to token data
+            setUser({
+              id: tokenPayload.id,
+              email: tokenPayload.email,
+              role: tokenPayload.role || "team_member",
+              permissions: {}, // Will be populated on login
+              isTeamMember: true,
+            });
+          }
         }
       } catch (error) {
         console.error("Error decoding token:", error);

--- a/controllers/teamController.js
+++ b/controllers/teamController.js
@@ -234,6 +234,52 @@ exports.teamMemberLogin = async (req, res) => {
   }
 };
 
+exports.getCurrentTeamMember = async (req, res) => {
+  try {
+    // Extract team member ID from token
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({ message: "No token provided" });
+    }
+
+    const token = authHeader.split(" ")[1];
+    let teamMemberId;
+
+    try {
+      // Decode the base64 token
+      const tokenPayload = JSON.parse(Buffer.from(token, "base64").toString());
+      teamMemberId = tokenPayload.id;
+    } catch (error) {
+      return res.status(401).json({ message: "Invalid token" });
+    }
+
+    const teamMember = await TeamMember.findById(teamMemberId)
+      .populate("department", "departmentId name description")
+      .select("-password");
+
+    if (!teamMember || !teamMember.isActive) {
+      return res.status(404).json({ message: "Team member not found" });
+    }
+
+    res.status(200).json({
+      message: "Current team member fetched successfully",
+      user: {
+        id: teamMember._id,
+        fullName: teamMember.fullName,
+        email: teamMember.email,
+        role: teamMember.role,
+        permissions: teamMember.permissions,
+        department: teamMember.department,
+      },
+    });
+  } catch (error) {
+    res.status(500).json({
+      message: "Failed to fetch current team member",
+      error: error.message,
+    });
+  }
+};
+
 exports.deleteTeamMember = async (req, res) => {
   try {
     const { id } = req.params; // team member ID

--- a/routes/teamRoutes.js
+++ b/routes/teamRoutes.js
@@ -21,6 +21,7 @@ router.get("/:memberId/assigned-chats", getAssignedChats);
 router.put("/update/:id", updateTeamMember);
 router.put("/permissions/:id", updatePermissions);
 router.post("/login", teamMemberLogin);
+router.get("/current", getCurrentTeamMember);
 router.delete("/:id", deleteTeamMember);
 
 module.exports = router;

--- a/routes/teamRoutes.js
+++ b/routes/teamRoutes.js
@@ -9,6 +9,7 @@ const {
   deleteTeamMember,
   updatePermissions,
   teamMemberLogin,
+  getCurrentTeamMember,
 } = require("../controllers/teamController");
 
 // Standard REST routes

--- a/server.js
+++ b/server.js
@@ -41,6 +41,7 @@ const allowedOrigins = [
   "https://admin.gsbpathy.com",
   "https://74c479b6a8d640b4b7bb7800e74a8fe9-8ef734e1b71d48d881c634dc0.fly.dev",
   "https://74c479b6a8d640b4b7bb7800e74a8fe9-d8916b10286a438ebde1b5aa5.fly.dev",
+  "https://74c479b6a8d640b4b7bb7800e74a8fe9-a36addc8dcd74549b827ef83b.fly.dev",
 ];
 
 app.use(


### PR DESCRIPTION
This pull request makes several improvements to team member authentication and permissions:

**Frontend Changes:**
- Updated Sidebar permission check to specifically target team_member role and check boolean permission values directly
- Modified AuthContext to wrap token initialization in async function and improved team member role handling
- Removed redundant role assignment for team members during login

**Backend Changes:**
- Added new `getCurrentTeamMember` endpoint to fetch current authenticated team member details
- Added corresponding route for the new endpoint at `/current`
- Updated CORS configuration to include new allowed origin

**Permission Logic:**
- Simplified permission checking to use direct boolean values instead of nested read properties
- Improved role consistency by using "team_member" throughout the codebase

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/74c479b6a8d640b4b7bb7800e74a8fe9/flare-haven)

👀 [Preview Link](https://74c479b6a8d640b4b7bb7800e74a8fe9-flare-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74c479b6a8d640b4b7bb7800e74a8fe9</projectId>-->
<!--<branchName>flare-haven</branchName>-->